### PR TITLE
feat: download as zip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12609,8 +12609,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "corejs-upgrade-webpack-plugin": {
       "version": "2.2.0",
@@ -17751,8 +17750,7 @@
     "immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
-      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps=",
-      "dev": true
+      "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immer": {
       "version": "1.10.0",
@@ -18450,8 +18448,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
@@ -20246,7 +20243,6 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.5.0.tgz",
       "integrity": "sha512-WRtu7TPCmYePR1nazfrtuF216cIVon/3GWOvHS9QR5bIwSbnxtdpma6un3jyGGNhHsKCSzn5Ypk+EkDRvTGiFA==",
-      "dev": true,
       "requires": {
         "lie": "~3.3.0",
         "pako": "~1.0.2",
@@ -20258,7 +20254,6 @@
           "version": "2.3.7",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
           "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
             "inherits": "~2.0.3",
@@ -20273,7 +20268,6 @@
           "version": "1.1.1",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "~5.1.0"
           }
@@ -20401,7 +20395,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
       "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
-      "dev": true,
       "requires": {
         "immediate": "~3.0.5"
       }
@@ -22756,8 +22749,7 @@
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
-      "dev": true
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
     },
     "parallel-transform": {
       "version": "1.2.0",
@@ -24702,8 +24694,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -27098,8 +27089,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.1",
@@ -31252,8 +31242,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "debug": "^4.1.1",
     "ethers": "^4.0.47",
     "file-saver": "^2.0.2",
+    "jszip": "^3.5.0",
     "polished": "^3.6.3",
     "pretty-bytes": "^5.3.0",
     "react": "^16.13.1",

--- a/src/components/DynamicFormContainer/DocumentPreview/DocumentPreview.tsx
+++ b/src/components/DynamicFormContainer/DocumentPreview/DocumentPreview.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, FunctionComponent } from "react";
+import React, { useState, useCallback, useRef, FunctionComponent, useEffect } from "react";
 import {
   FrameConnector,
   HostActions,
@@ -16,6 +16,13 @@ interface DocumentPreview {
 export const DocumentPreview: FunctionComponent<DocumentPreview> = ({ document }) => {
   const toFrame = useRef<Dispatch>();
   const [height, setHeight] = useState(0);
+
+  // Update document preview every time when the user navigates through the different documents
+  useEffect(() => {
+    if (toFrame.current) {
+      toFrame.current(renderDocument({ document }));
+    }
+  }, [document]);
 
   const rendererUrl = document["$template"]?.url;
   const onConnected = useCallback(

--- a/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
+++ b/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
@@ -1,4 +1,5 @@
 import prettyBytes from "pretty-bytes";
+import { saveAs } from "file-saver";
 import React, { FunctionComponent } from "react";
 import { useConfigContext } from "../../../common/context/config";
 import { useFormsContext } from "../../../common/context/forms";
@@ -10,6 +11,7 @@ import { Button } from "../../UI/Button";
 import { CheckCircle, Download, XCircle } from "react-feather";
 import { Title } from "../../UI/Title";
 import { PublishedTag } from "../PublishedScreen/PublishedTag";
+import JSZip from "jszip";
 
 interface PublishScreen {
   publishedDocuments: WrappedDocument[];
@@ -22,7 +24,20 @@ export const PublishedScreen: FunctionComponent<PublishScreen> = ({
 }) => {
   const { setConfig, config } = useConfigContext();
   const { setForms, setActiveFormIndex } = useFormsContext();
-
+  console.log(publishedDocuments);
+  const downloadAsZip = (): void => {
+    if (publishedDocuments) {
+      const zip = new JSZip();
+      publishedDocuments.map((doc) => {
+        const extension = doc.extension ? doc.extension : "tt";
+        const fileName = generateFileName(config, doc.fileName, extension);
+        zip.file(fileName, JSON.stringify(doc.wrappedDocument, null, 2));
+      });
+      zip.generateAsync({ type: "blob" }).then(function (content) {
+        saveAs(content, "Documents.zip");
+      });
+    }
+  };
   const createAnotherDoc = (): void => {
     setForms([]);
     setActiveFormIndex(undefined);
@@ -63,6 +78,9 @@ export const PublishedScreen: FunctionComponent<PublishScreen> = ({
               : "Document(s) failed to issue"}
           </Title>
           <div>
+            <Button className="bg-white text-orange px-4 py-3 mb-6 mr-4" onClick={downloadAsZip}>
+              Download as Zip
+            </Button>
             <Button className="bg-white text-orange px-4 py-3 mb-6 mr-4" onClick={createAnotherDoc}>
               Create another Document
             </Button>

--- a/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
+++ b/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
@@ -24,11 +24,11 @@ export const PublishedScreen: FunctionComponent<PublishScreen> = ({
 }) => {
   const { setConfig, config } = useConfigContext();
   const { setForms, setActiveFormIndex } = useFormsContext();
-  console.log(publishedDocuments);
+
   const downloadAsZip = (): void => {
     if (publishedDocuments) {
       const zip = new JSZip();
-      publishedDocuments.map((doc) => {
+      publishedDocuments.forEach((doc): void => {
         const extension = doc.extension ? doc.extension : "tt";
         const fileName = generateFileName(config, doc.fileName, extension);
         zip.file(fileName, JSON.stringify(doc.wrappedDocument, null, 2));


### PR DESCRIPTION
In this MR, 

- Added the `Download as Zip` button
- Uses `jszip` library to zip up all our documents

### To test

1. Download the [config](https://gist.githubusercontent.com/gjj/f76508b1b6e6b2ebab3658426ba09931/raw/4102dc0124071b5cb19f025e87bd9429469b8388/config-govtech-intern-certs.json) and the [sample data file](https://gist.githubusercontent.com/gjj/6d7601c8a1778c4d08ed0df7891c9310/raw/07044a86172c3c3ec451f684b45a9d4cfe5c286b/Internship%2520ACCESS%2520sample.csv) (right click, save as)
1. Go to the [doc creator](https://deploy-preview-2--govtech-intern-certs-demo.netlify.app/)
1. Drag and drop the config file into the dropzone
1. Enter password `password`
1. Choose `Certificate of Achievement` (at the `Step 1/3: Choose Type` page)
1. Click the `Upload Data File` and upload the .csv file
1. Click `Issue Document`
1. Click `Download as Zip`!

### Todo

- Write tests

### Screens
The new `Download as Zip` button
![image](https://user-images.githubusercontent.com/506667/94506909-11d16f00-0241-11eb-832b-9acaef419220.png)

Downloaded `.zip` file
![image](https://user-images.githubusercontent.com/506667/94506924-1eee5e00-0241-11eb-8016-170e5fa9db18.png)
