### PR TITLE
fix: custom file extension

### DIFF
--- a/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
+++ b/src/components/PublishContainer/PublishedScreen/PublishedScreen.tsx
@@ -98,10 +98,11 @@ export const PublishedScreen: FunctionComponent<PublishScreen> = ({
               </div>
               {failPublishedDocuments.map((doc, index) => {
                 const size = prettyBytes(getFileSize(JSON.stringify(doc.wrappedDocument)));
+                const extension = doc.extension ? doc.extension : "tt";
                 return (
                   <div key={index} className="flex items-center">
                     <div className="font-bold text-lightgrey-dark">
-                      {generateFileName(config, doc.fileName, "tt")}
+                      {generateFileName(config, doc.fileName, extension)}
                     </div>
                     <div className="text-xs text-lightgrey-dark ml-1">({size})</div>
                   </div>


### PR DESCRIPTION
In this MR, we allow custom file extension (fetched from config file's `extension`), instead of the default hardcoded `.tt` extension.

Accidentally left this out when rebasing.

### To test

1. Download the [config](https://gist.githubusercontent.com/gjj/f76508b1b6e6b2ebab3658426ba09931/raw/ea93cce8110db3ff460731df18ed7697e5e2229a/config-govtech-intern-certs.json) and the [sample data file](https://gist.githubusercontent.com/gjj/6d7601c8a1778c4d08ed0df7891c9310/raw/07044a86172c3c3ec451f684b45a9d4cfe5c286b/Internship%2520ACCESS%2520sample.csv) (right click, save as, **make sure it is** `.csv` as it defaults to `.txt`)
1. Go to the [doc creator](https://govtech-intern-certs-demo.netlify.app/)
1. Drag and drop the config file into the dropzone
1. Enter password `password`
1. Choose `Certificate of Achievement` (at the `Step 1/3: Choose Type` page)
1. Click the `Upload Data File` and upload the .csv file
1. Click `Issue Document`